### PR TITLE
Switch Xcode archive unpacking task to xip

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,7 +15,7 @@
         grep \"Status: signed Apple Software\"
 
     - name: Install Xcode from XIP file Location
-      command: open -FWga "Archive Utility" --args {{ xcode_xip_location }}
+      command: xip --expand {{ xcode_xip_location }}
 
     - name: Move Xcode To Applications
       shell: mv {{ xcode_xip_location | dirname }}/Xcode*.app /Applications/


### PR DESCRIPTION
This makes use of a proper cli utility instead of spawning a GUI app

I've only tested this change on macOS 10.15 with Xcode 11.5