### PR TITLE
Update Xcode installation check to search /Applications only

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,5 @@
 - name: Check if Xcode is installed
-  command: mdfind "kMDItemCFBundleIdentifier == 'com.apple.dt.Xcode'"
+  command: mdfind -onlyin /Applications "kMDItemCFBundleIdentifier == 'com.apple.dt.Xcode'"
   register: xcode_app
   changed_when: false
 


### PR DESCRIPTION
Fix an issue where mdfind can match an extracted xip/app file outside of
Applications directory and falsely indicate an Xcode installation exists.