### PR TITLE
Streamline shell mv into XIP with chdir

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,8 +17,10 @@
     - name: Install Xcode from XIP file Location
       command: xip --expand {{ xcode_xip_location }}
 
-    - name: Move Xcode To Applications
-      shell: mv {{ xcode_xip_location | dirname }}/Xcode*.app /Applications/
+    - name: Install Xcode from XIP file Location
+      command: xip --expand {{ xcode_xip_location }}
+      args:
+        chdir: /Applications
 
     - name: Accept License Agreement
       command: "{{ xcode_build }} -license accept"


### PR DESCRIPTION
xip prefers to extract to the current working directory, add a chdir
to /Applications to allow us to safely remove the shell module call.