### PR TITLE
Avoid SSH Timeouts on XIP Install with Async w/poll

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,6 +16,10 @@
 
     - name: Install Xcode from XIP file Location
       command: xip --expand {{ xcode_xip_location }}
+      args:
+        chdir: /Applications
+      poll: 5
+      async: 800 # Prevent SSH connections timing out waiting for extraction
 
     - name: Move Xcode To Applications
       shell: mv {{ xcode_xip_location | dirname }}/Xcode*.app /Applications/


### PR DESCRIPTION
Remedy an issue where SSH connections were timing out for ansible
during XIP Extraction which seems to take at least 7-8 minutes.
Just long enough for the connection to drop under ansible.