### PR TITLE
Fix move of xip output content (Xcode.app)

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,7 +18,7 @@
       command: xip --expand {{ xcode_xip_location }}
 
     - name: Move Xcode To Applications
-      shell: mv {{ xcode_xip_location | dirname }}/Xcode*.app /Applications/
+      shell: mv {{ ansible_env.PWD }}/Xcode*.app /Applications/
 
     - name: Accept License Agreement
       command: "{{ xcode_build }} -license accept"


### PR DESCRIPTION
xip does not support specifying output directory, instead the archive will be extracted to the current working directory. Ensure PWD is used instead of the directory of Xcode xip file.
