### PR TITLE
Add macOS 11.00 (Big Sur) as supported platform

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -15,12 +15,13 @@ galaxy_info:
         - '10.13'
         - '10.14'
         - '10.15'
+        - '11.00'
 
   galaxy_tags:
     - 'mac'
     - 'osx'
-    - 'highsierra'
     - 'sierra'
+    - 'highsierra'
     - 'mojave'
     - 'catalina'
     - 'bigsur'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,7 +29,7 @@
 
 - name: Install Xcode
   block:
-    - name: check that the xcode archive is valid
+    - name: Check that the Xcode archive is valid
       command: >
         pkgutil --check-signature {{ xcode_xip_location }} |
         grep \"Status: signed Apple Software\"


### PR DESCRIPTION
This will undo the pull request #11. 

According to your documentation, macOS 11.00 (Big Sur) is now supported. 
* https://docs.macstadium.com/docs/macos-version-in-your-vmware-cloud