### PR TITLE
Defaults to Xcode 8 when version check fails

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,7 +8,7 @@
     xcode_installed: "{{ xcode_app.stdout.find('Xcode') != -1 }}"
 
 - name: Get Installed Xcode version
-  shell: xcodebuild -version | head -n1 | cut -d " " -f 2
+  shell: (xcodebuild -version 2> /dev/null || echo "8.0") | head -n1 | cut -d " " -f 2
   register: xcode_app_output
   when: xcode_installed
   changed_when: false


### PR DESCRIPTION
The script `xcodebuild -version | head -n1 | cut -d " " -f 2` can fail with an error if Xcode is misconfigured, e.g.: 
`xcrun: error: invalid active developer path (/Applications/Xcode.app/Contents/Developer), missing xcrun at: /Applications/Xcode.app/Contents/Developer/usr/bin/xcrun`

If the error is returned, this patch assumes that `xcodebuil -version` returned `8.0` and it will always install the new version.