### PR TITLE
Fix Xcode CLT path if both CLT & Xcode is installed

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,6 +7,11 @@
   set_fact:
     xcode_installed: "{{ xcode_app.stdout.find('Xcode') != -1 }}"
 
+- name: Set Xcode command line tools path if Xcode is installed
+  become: true
+  shell: xcode-select -s "{{ xcode_app.stdout }}"
+  when: xcode_installed
+
 - name: Get Installed Xcode version
   shell: xcodebuild -version | head -n1 | cut -d " " -f 2
   register: xcode_app_output


### PR DESCRIPTION
If Xcode Command Line Tools is installed at the moment of playbook execution and `xcode-select` path is set to CLT, then step `Get Installed Xcode version` would fail with `xcodebuild` error:

``` 
TASK [Gathering Facts] *********************************************************
ok: [localhost]

TASK [macstadium.xcode : Check if Xcode is installed] **************************
ok: [localhost] => {"changed": false, "cmd": ["mdfind", "-onlyin", "/Applications", "kMDItemCFBundleIdentifier == 'com.apple.dt.Xcode'"], "delta": "0:00:00.081954", "end": "2022-04-04 17:37:25.955265", "msg": "", "rc": 0, "start": "2022-04-04 17:37:25.873311", "stderr": "", "stderr_lines": [], "stdout": "/Applications/Xcode.app", "stdout_lines": ["/Applications/Xcode.app"]}

TASK [macstadium.xcode : Register xcode_installed] *****************************
ok: [localhost] => {"ansible_facts": {"xcode_installed": true}, "changed": false}

TASK [macstadium.xcode : Get Installed Xcode version] **************************
ok: [localhost] => {"changed": false, "cmd": "xcodebuild -version | head -n1 | cut -d \" \" -f 2", "delta": "0:00:00.015405", "end": "2022-04-04 17:37:26.360811", "msg": "", "rc": 0, "start": "2022-04-04 17:37:26.345406", "stderr": "xcode-select: error: tool 'xcodebuild' requires Xcode, but active developer directory '/Library/Developer/CommandLineTools' is a command line tools instance", "stderr_lines": ["xcode-select: error: tool 'xcodebuild' requires Xcode, but active developer directory '/Library/Developer/CommandLineTools' is a command line tools instance"], "stdout": "", "stdout_lines": []}

TASK [macstadium.xcode : Export Installed Xcode version] ***********************
ok: [localhost] => {"ansible_facts": {"xcode_installed_version": ""}, "changed": false}

TASK [macstadium.xcode : Get Candidate Xcode version] **************************
ok: [localhost] => {"changed": false, "cmd": "echo -n \"/Users/test/Downloads/Xcode_13.3.xip\" | cut -d \"_\" -f 2 | sed s/'.xip'//g", "delta": "0:00:00.013016", "end": "2022-04-04 17:37:26.744190", "msg": "", "rc": 0, "start": "2022-04-04 17:37:26.731174", "stderr": "", "stderr_lines": [], "stdout": "13.3", "stdout_lines": ["13.3"]}

TASK [macstadium.xcode : Export Candidate Xcode version] ***********************
ok: [localhost] => {"ansible_facts": {"xcode_target_version": "13.3"}, "changed": false}

TASK [macstadium.xcode : check that the xcode archive is valid] ****************
fatal: [localhost]: FAILED! => {"msg": "The conditional check 'not xcode_installed or xcode_installed_version is version(xcode_target_version, '!=')' failed. The error was: Input version value cannot be empty\n\nThe error appears to be in '/Users/test/.ansible/roles/macstadium.xcode/tasks/main.yml': line 32, column 7, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n  block:\n    - name: check that the xcode archive is valid\n      ^ here\n"}

PLAY RECAP *********************************************************************
localhost                  : ok=7    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0  
```

<img width="1120" alt="Screenshot 2022-04-04 at 17 46 49" src="https://user-images.githubusercontent.com/29863293/161569778-1116316c-3449-4788-95f4-6af1962c249e.png">


This newly added step assures that xcode clt path is set to actual xcode installation