### PR TITLE
support check-mode

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,6 +2,7 @@
   command: mdfind -onlyin /Applications "kMDItemCFBundleIdentifier == 'com.apple.dt.Xcode'"
   register: xcode_app
   changed_when: false
+  check_mode: no
 
 - name: Register xcode_installed
   set_fact:
@@ -12,6 +13,7 @@
   register: xcode_app_output
   when: xcode_installed
   changed_when: false
+  check_mode: no
 
 - name: Export Installed Xcode version
   set_fact:
@@ -22,6 +24,7 @@
   shell: echo -n "{{ xcode_xip_location }}" | cut -d "_" -f 2 | sed s/'.xip'//g
   register: xcode_path_parse
   changed_when: false
+  check_mode: no
 
 - name: Export Candidate Xcode version
   set_fact:


### PR DESCRIPTION
tag information-retrieval commands to run even in check-mode, so their result can be used. (thus check-mode will report if an installation is required. without this change the configurations errors in check-mode)